### PR TITLE
[ISACDEVIND-7] Dhyana4040 binning management

### DIFF
--- a/include/DhyanaCamera.h
+++ b/include/DhyanaCamera.h
@@ -213,6 +213,17 @@ private:
             return false;
         }
     }
+    inline bool is_dhyana_4040()
+	{
+		std::string model="UNKNOWN";
+		getDetectorModel(model);
+		
+		if (model.find("4040") != std::string::npos)
+		{
+			return true;
+		}
+		return false;
+	}
 
     void createParametersMap();
     std::stringstream getParameterValue(std::string parameter_name, int parameter_id);

--- a/include/DhyanaCamera.h
+++ b/include/DhyanaCamera.h
@@ -202,29 +202,7 @@ private:
     bool readFrame(void *bptr, int& frame_nb);
     void setStatus(Camera::Status status, bool force);    
 	void _startAcq();
-    inline bool IS_POWER_OF_2(long x)
-    {
-        if( ((x ^ (x - 1)) == x + (x - 1)) && (x != 0) )
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
-    }
-    inline bool is_dhyana_4040()
-	{
-		std::string model="UNKNOWN";
-		getDetectorModel(model);
-		
-		if (model.find("4040") != std::string::npos)
-		{
-			return true;
-		}
-		return false;
-	}
-
+    bool is_dhyana_4040();
     void createParametersMap();
     std::stringstream getParameterValue(std::string parameter_name, int parameter_id);
 

--- a/src/DhyanaCamera.cpp
+++ b/src/DhyanaCamera.cpp
@@ -947,15 +947,8 @@ void Camera::checkBin(Bin &hw_bin)
 		std::vector<int> binningValues = {1, 2, 4};
 
 		// Binning is available since version 2.0.7 for Dhyana 4040
-		std::string model="UNKNOWN";
-		getDetectorModel(model);
-		if (model == "Dhyana 95"  || model.find("Dhyana 95 V2") != std::string::npos)
-		{
-			DEB_ERROR() << "Binning is not supported for Dhyana 95 detectors, binning is set to 1x1";
-			m_bin = Bin(1, 1);
-			hw_bin = m_bin;
-		}
-		else if (model.find("4040") != std::string::npos)
+
+		if (is_dhyana_4040())
 		{
 			int x = hw_bin.getX();
 			int y = hw_bin.getY();
@@ -968,7 +961,7 @@ void Camera::checkBin(Bin &hw_bin)
 		}
 		else
 		{
-			DEB_ERROR() << "Detector model unknown, binning is set to 1x1";
+			DEB_ERROR() << "Binning is not supported for this model, binning is set to 1x1";
 			m_bin = Bin(1, 1);
 			hw_bin = m_bin;
 		}
@@ -1000,13 +993,8 @@ void Camera::setBin(const Bin& set_bin)
 
 	#ifdef BINNING_4040_ENABLED
 		// Binning is available since version 2.0.7 for Dhyana 4040
-		std::string model="UNKNOWN";
-		getDetectorModel(model);
-		if (model == "Dhyana 95"  || model.find("Dhyana 95 V2") != std::string::npos)
-		{
-			DEB_ERROR() << "Binning is not supported for Dhyana 95 detectors, binning is set to 1x1";
-		}
-		else if (model.find("4040") != std::string::npos)
+
+		if (is_dhyana_4040())
 		{
 			if (set_bin != m_bin)
 			{
@@ -1024,7 +1012,7 @@ void Camera::setBin(const Bin& set_bin)
 		}
 		else
 		{
-			DEB_ERROR() << "Detector model unknown, binning is set to 1x1";
+			m_bin = set_bin;
 		}
 	#else
 		m_bin = set_bin;

--- a/src/DhyanaCamera.cpp
+++ b/src/DhyanaCamera.cpp
@@ -1688,6 +1688,21 @@ std::stringstream Camera::getParameterValue(std::string parameter_name, int para
 	return result;
 }
 
+//---------------------------------------
+// @brief Get if camera model is Dhayna4040
+//---------------------------------------
+bool Camera::is_dhyana_4040()
+{
+	std::string model="UNKNOWN";
+	getDetectorModel(model);
+	
+	if (model.find("4040") != std::string::npos)
+	{
+		return true;
+	}
+	return false;
+}
+
 //--------------------------------------------------------
 // @brief Create a map including all availbla parameters 
 //--------------------------------------------------------


### PR DESCRIPTION
Implemented binning management for Dhyana 4040 cameras, and added camera model check to avoid setting binning parameters if the camera used is a Dhyana 95.

Due to several bugs with Roi management in Lima, the binning management has been disabled with a #ifdef statement.
To enable the binning, compile with flag BINNING_4040_ENABLED.